### PR TITLE
feat(import): upload a ZIP of images as pending pose frames

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,9 @@ datasets. Two keypoint schemas ship by default: **17-point infant pose
 NeoLabel covers the path from raw video to a trainable dataset in four
 steps:
 
-1. **Upload videos** at a chosen FPS — FFmpeg extracts the frames.
-   Optionally resize to **640×640** (letterbox or stretch). Optionally
+1. **Upload videos** at a chosen FPS — FFmpeg extracts the frames — or
+   **upload a ZIP of images** to import each one as a frame. Either way,
+   optionally resize to **640×640** (letterbox or stretch). You can also
    **import an existing COCO keypoints dataset** to start from
    pre-annotated items.
 2. **Assign work** — admins assign whole videos to a specific annotator

--- a/SPEC.md
+++ b/SPEC.md
@@ -13,7 +13,8 @@ diverges, update the spec **before** the code.
 - ✅ **Phase 2 — Text labeling MVP.** Labels, bulk item upload,
   keyboard-driven annotation UI, exports (JSON/JSONL/CSV).
 - ✅ **Phase 3 — Pose detection.** Video upload with FFmpeg frame
-  extraction, keyboard-driven annotation, YOLO-pose ZIP export.
+  extraction (or a raw-image ZIP imported as pending frames),
+  keyboard-driven annotation, YOLO-pose ZIP export.
   Keypoint schemas: infant pose (17 COCO, `BabyAvatar` guide) and
   rodent pose (7 keypoints) for behavioral assays (OF / EPM). See §2.
 - ✅ **Phase 4 — Multi-user assignments.** `admin` role, per-user
@@ -220,6 +221,18 @@ user does not own returns **404** (to avoid leaking existence), with
   ∈ {0, 90, 180, 270} applies an FFmpeg `transpose` so extracted
   frames come out upright. `assignee_id` is optional — omit to leave
   every extracted frame unassigned (admin-pool only).
+- `POST   /projects/{id}/import-images` — admin-only, pose projects only
+  (400 otherwise); form(`file`, `assignee_id?`, `resize_mode` ∈
+  {`pad`, `stretch`}, default `pad`). Streams an image ZIP to disk in
+  1 MiB chunks (caps at **500 MiB** → 413), extracts with path-traversal
+  guards, and creates one **pending** item per image (`.jpg`/`.jpeg`/
+  `.png`, found recursively). Each image is re-encoded to 640×640 with
+  the same FFmpeg resize as video upload, so image frames and video
+  frames are interchangeable. All images flatten into one source group
+  named after the ZIP; `frame_index` continues past any existing frames
+  in that group. Returns `{items_created, skipped_files, source_video,
+  resize_mode}`. 400 on empty / invalid ZIP / no images / bad
+  `resize_mode`.
 - `GET    /projects/{id}/videos` — admin overview (per-video
   `frames`, `done`, `assigned_to` — `null` when unassigned or mixed)
 - `PATCH  /projects/{id}/videos/{source}/assign` — admin-only;

--- a/backend/app/api/v1/videos.py
+++ b/backend/app/api/v1/videos.py
@@ -2,6 +2,7 @@ from fastapi import APIRouter, File, Form, HTTPException, UploadFile, status
 
 from app.core.deps import AdminUser
 from app.schemas.item import ReassignRequest, RotateRequest
+from app.services import image_import as image_import_service
 from app.services import import_coco as import_coco_service
 from app.services import item as item_service
 from app.services import project as project_service
@@ -97,6 +98,45 @@ async def import_coco_pose(
             else status.HTTP_400_BAD_REQUEST
         )
         raise HTTPException(code, str(e))
+
+
+@router.post(
+    "/projects/{project_id}/import-images",
+    status_code=status.HTTP_201_CREATED,
+    tags=["videos"],
+)
+async def import_images(
+    project_id: int,
+    current_user: AdminUser,
+    file: UploadFile = File(...),
+    assignee_id: int | None = Form(None),
+    resize_mode: str = Form("pad"),
+) -> dict:
+    project = _require_project(project_id)
+    if project.type.value != "pose_detection":
+        raise HTTPException(
+            status.HTTP_400_BAD_REQUEST,
+            "Image import is only available for pose_detection projects",
+        )
+    if assignee_id is not None:
+        _require_user(assignee_id)
+    try:
+        return image_import_service.import_images(
+            project_id,
+            file.file,
+            file.filename or "images.zip",
+            assignee_id=assignee_id,
+            resize_mode=resize_mode,
+        )
+    except ValueError as e:
+        code = (
+            status.HTTP_413_REQUEST_ENTITY_TOO_LARGE
+            if "larger than" in str(e).lower()
+            else status.HTTP_400_BAD_REQUEST
+        )
+        raise HTTPException(code, str(e))
+    except RuntimeError as e:
+        raise HTTPException(status.HTTP_500_INTERNAL_SERVER_ERROR, str(e))
 
 
 @router.get("/projects/{project_id}/videos", tags=["videos"])

--- a/backend/app/services/frames.py
+++ b/backend/app/services/frames.py
@@ -1,0 +1,25 @@
+"""Shared frame geometry for the video uploader and the image importer.
+
+Both ingest paths normalize every frame to one fixed square so video frames and
+imported image frames are byte-consistent and export geometry is uniform.
+"""
+from __future__ import annotations
+
+TARGET_SIZE = 640
+PAD_COLOR = "black"
+RESIZE_MODES = ("stretch", "pad")
+
+
+def resize_filter(mode: str) -> str:
+    """ffmpeg `-vf` value that fits a source into TARGET_SIZE x TARGET_SIZE.
+
+    "stretch" scales freely (distorts non-square sources); "pad" scales the
+    longer edge to TARGET_SIZE then pads the shorter edge with a solid border
+    to preserve aspect ratio (Ultralytics' letterbox convention).
+    """
+    if mode == "stretch":
+        return f"scale={TARGET_SIZE}:{TARGET_SIZE}"
+    return (
+        f"scale={TARGET_SIZE}:{TARGET_SIZE}:force_original_aspect_ratio=decrease,"
+        f"pad={TARGET_SIZE}:{TARGET_SIZE}:(ow-iw)/2:(oh-ih)/2:color={PAD_COLOR}"
+    )

--- a/backend/app/services/image_import.py
+++ b/backend/app/services/image_import.py
@@ -1,0 +1,159 @@
+"""Import a ZIP of raw images into a pose_detection project as pending frames.
+
+Mirrors `import_coco`'s ZIP plumbing (stream-to-disk cap, path-safe extract) but
+there is no annotation index: every image becomes one unannotated `pending`
+item, resized to the shared TARGET_SIZE exactly like a video frame, so imported
+image frames and extracted video frames are interchangeable downstream.
+
+All images in the archive flatten into a single source group named after the
+ZIP file (subfolders are walked recursively but ignored for grouping).
+"""
+from __future__ import annotations
+
+import re
+import shutil
+import subprocess
+import tempfile
+import zipfile
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import BinaryIO
+
+from app.core import storage
+from app.schemas.item import ItemStatus
+from app.services import frames
+
+
+_SAFE = re.compile(r"[^A-Za-z0-9_.-]+")
+_MAX_ZIP_BYTES = 500 * 1024 * 1024    # 500 MiB — same cap as video / COCO import
+_CHUNK_BYTES = 1024 * 1024            # 1 MiB
+_IMAGE_SUFFIXES = {".jpg", ".jpeg", ".png"}
+
+
+def _safe_name(name: str) -> str:
+    stem = Path(name).stem
+    return _SAFE.sub("_", stem) or "images"
+
+
+def _safe_extract(zf: zipfile.ZipFile, dest: Path) -> None:
+    dest = dest.resolve()
+    for member in zf.infolist():
+        name = member.filename
+        if name.endswith("/"):
+            continue
+        p = Path(name)
+        if p.is_absolute() or any(part == ".." for part in p.parts):
+            raise ValueError(f"Unsafe path in archive: {name}")
+        target = (dest / p).resolve()
+        if dest not in target.parents:
+            raise ValueError(f"Unsafe path in archive: {name}")
+        target.parent.mkdir(parents=True, exist_ok=True)
+        with zf.open(member) as src, open(target, "wb") as out:
+            shutil.copyfileobj(src, out)
+
+
+def import_images(
+    project_id: int,
+    source: BinaryIO,
+    filename: str,
+    assignee_id: int | None = None,
+    resize_mode: str = "pad",
+) -> dict:
+    """Stream an image ZIP, resize every image to TARGET_SIZE, and create one
+    pending item per image under a single group named after the ZIP.
+
+    `frame_index` continues contiguously past any existing frames in the group,
+    so re-uploading under the same name extends it instead of colliding.
+
+    Returns {items_created, skipped_files, source_video, resize_mode}.
+    Raises ValueError on bad params / empty file / not-a-zip / no images, and
+    RuntimeError if ffmpeg fails on an image.
+    """
+    if resize_mode not in frames.RESIZE_MODES:
+        raise ValueError(f"resize_mode must be one of: {', '.join(frames.RESIZE_MODES)}")
+
+    source_name = _safe_name(filename)
+    vf = frames.resize_filter(resize_mode)
+
+    with tempfile.TemporaryDirectory(prefix="neolabel-images-") as td:
+        tmp = Path(td)
+        archive_path = tmp / "upload.zip"
+
+        # 1. Stream upload to disk with a cap.
+        written = 0
+        with archive_path.open("wb") as out:
+            while chunk := source.read(_CHUNK_BYTES):
+                written += len(chunk)
+                if written > _MAX_ZIP_BYTES:
+                    raise ValueError("Archive larger than 500 MB")
+                out.write(chunk)
+        if written == 0:
+            raise ValueError("Empty file")
+
+        # 2. Extract with path-traversal checks.
+        extract_dir = tmp / "extract"
+        extract_dir.mkdir()
+        try:
+            with zipfile.ZipFile(archive_path) as zf:
+                _safe_extract(zf, extract_dir)
+        except zipfile.BadZipFile as e:
+            raise ValueError(f"Not a valid ZIP: {e}")
+
+        # 3. Collect image files (recursively, flattened); count other files.
+        images: list[Path] = []
+        skipped_files = 0
+        for p in sorted(extract_dir.rglob("*")):
+            if not p.is_file():
+                continue
+            if p.suffix.lower() in _IMAGE_SUFFIXES:
+                images.append(p)
+            else:
+                skipped_files += 1
+        if not images:
+            raise ValueError("No images found in archive")
+
+        pdir = storage.project_dir(project_id)
+        frames_dir = pdir / "frames" / source_name
+        frames_dir.mkdir(parents=True, exist_ok=True)
+
+        # Continue numbering past any frames already in this group.
+        start = len(list(frames_dir.glob("f_*.*")))
+
+        now = datetime.now(timezone.utc).isoformat()
+        items_created = 0
+        for offset, src_img in enumerate(images, 1):
+            frame_idx = start + offset
+            dest = frames_dir / f"f_{frame_idx:06d}.jpg"
+            cmd = [
+                "ffmpeg", "-y", "-loglevel", "warning",
+                "-i", str(src_img), "-vf", vf, "-q:v", "2", str(dest),
+            ]
+            result = subprocess.run(cmd, capture_output=True, text=True)
+            if result.returncode != 0:
+                raise RuntimeError(
+                    f"ffmpeg failed: {result.stderr.strip() or result.stdout.strip()}"
+                )
+            rel = dest.relative_to(storage._root())
+            iid = storage.next_id("items")
+            storage.save_item({
+                "id": iid,
+                "project_id": project_id,
+                "payload": {
+                    "image_url": f"/files/{rel.as_posix()}",
+                    "source_video": source_name,
+                    "frame_index": frame_idx,
+                    "width": frames.TARGET_SIZE,
+                    "height": frames.TARGET_SIZE,
+                },
+                "status": ItemStatus.pending.value,
+                "created_at": now,
+                "assigned_to": assignee_id,
+            })
+            items_created += 1
+
+    return {
+        "items_created": items_created,
+        "skipped_files": skipped_files,
+        "source_video": source_name,
+        "resize_mode": resize_mode,
+    }

--- a/backend/app/services/video.py
+++ b/backend/app/services/video.py
@@ -12,14 +12,16 @@ from typing import BinaryIO
 
 from app.core import storage
 from app.schemas.item import ItemStatus
+# Import names directly: several functions here use a local `frames` variable,
+# so importing the module would shadow it (UnboundLocalError).
+from app.services.frames import RESIZE_MODES, TARGET_SIZE, resize_filter
 
 
 _SAFE = re.compile(r"[^A-Za-z0-9_.-]+")
 _MAX_VIDEO_BYTES = 500 * 1024 * 1024    # 500 MiB
 _CHUNK_BYTES = 1024 * 1024              # 1 MiB
-_TARGET_SIZE = 640
-_PAD_COLOR = "black"
-_RESIZE_MODES = ("stretch", "pad")
+_TARGET_SIZE = TARGET_SIZE              # shared with the image importer
+_RESIZE_MODES = RESIZE_MODES
 
 
 def _probe_duration_s(path: Path) -> float | None:
@@ -173,17 +175,6 @@ def rotate_video(project_id: int, source_video: str, degrees: int) -> int:
     return len(frames)
 
 
-def _resize_filter(mode: str) -> str:
-    if mode == "stretch":
-        return f"scale={_TARGET_SIZE}:{_TARGET_SIZE}"
-    # "pad" — scale the longer edge to 640 then pad the shorter edge with
-    # solid color. Matches Ultralytics' letterbox convention.
-    return (
-        f"scale={_TARGET_SIZE}:{_TARGET_SIZE}:force_original_aspect_ratio=decrease,"
-        f"pad={_TARGET_SIZE}:{_TARGET_SIZE}:(ow-iw)/2:(oh-ih)/2:color={_PAD_COLOR}"
-    )
-
-
 def extract_frames(
     project_id: int,
     source: BinaryIO,
@@ -235,7 +226,7 @@ def extract_frames(
     # `round=up` ensures the last boundary frame is kept instead of dropped,
     # which otherwise undercounts short clips by one.
     filters.append(f"fps=fps={fps}:round=up")
-    filters.append(_resize_filter(resize_mode))
+    filters.append(resize_filter(resize_mode))
     vf = ",".join(filters)
 
     frames_dir = pdir / "frames" / name

--- a/backend/tests/test_image_import.py
+++ b/backend/tests/test_image_import.py
@@ -1,0 +1,223 @@
+"""Tests for the raw-image ZIP importer (POST /projects/{id}/import-images).
+
+Unlike the assignment tests, these exercise the real ffmpeg resize path so we
+can assert that imported frames land at 640x640 just like video frames. Test
+images are generated with ffmpeg's lavfi source and probed back with ffprobe;
+both binaries are a hard dependency of the feature anyway.
+"""
+from __future__ import annotations
+
+import io
+import subprocess
+import zipfile
+
+import pytest
+
+
+# --- helpers ---------------------------------------------------------------
+
+def _img_bytes(w: int, h: int, color: str = "red", fmt: str = "mjpeg") -> bytes:
+    """A real JPEG/PNG of size w x h via ffmpeg, returned as bytes (no temp file)."""
+    cmd = [
+        "ffmpeg", "-v", "error",
+        "-f", "lavfi", "-i", f"color=c={color}:s={w}x{h}",
+        "-frames:v", "1", "-f", "image2pipe", "-vcodec", fmt, "-",
+    ]
+    r = subprocess.run(cmd, capture_output=True)
+    if r.returncode != 0:
+        raise RuntimeError(r.stderr.decode())
+    return r.stdout
+
+
+def _zip(files: dict[str, bytes]) -> bytes:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        for name, data in files.items():
+            zf.writestr(name, data)
+    return buf.getvalue()
+
+
+def _probe_size(path) -> tuple[int, int]:
+    r = subprocess.run(
+        [
+            "ffprobe", "-v", "error", "-select_streams", "v:0",
+            "-show_entries", "stream=width,height", "-of", "csv=p=0", str(path),
+        ],
+        capture_output=True, text=True,
+    )
+    w, h = r.stdout.strip().split(",")
+    return int(w), int(h)
+
+
+def _frames_dir(data_dir, project_id: int, source: str):
+    return data_dir / "projects" / str(project_id) / "frames" / source
+
+
+# --- fixtures --------------------------------------------------------------
+
+@pytest.fixture
+def pose_project(client, admin_headers) -> dict:
+    r = client.post(
+        "/api/v1/projects",
+        json={"name": "img-proj", "type": "pose_detection"},
+        headers=admin_headers,
+    )
+    return r.json()
+
+
+def _post_images(client, headers, project_id, zip_bytes, **data):
+    return client.post(
+        f"/api/v1/projects/{project_id}/import-images",
+        files={"file": ("photos.zip", zip_bytes, "application/zip")},
+        data={k: str(v) for k, v in data.items()},
+        headers=headers,
+    )
+
+
+# --- tests -----------------------------------------------------------------
+
+def test_imports_images_as_pending_640_frames(
+    client, admin_headers, pose_project, _isolated_data_dir
+):
+    z = _zip({
+        "a.jpg": _img_bytes(320, 240),
+        "b.jpg": _img_bytes(800, 600),
+        "c.png": _img_bytes(100, 400, fmt="png"),
+    })
+    r = _post_images(client, admin_headers, pose_project["id"], z)
+    assert r.status_code == 201, r.text
+    body = r.json()
+    assert body["items_created"] == 3
+    assert body["source_video"] == "photos"
+
+    # every imported item is a pending frame in the "photos" group
+    items = client.get(
+        f"/api/v1/projects/{pose_project['id']}/items", headers=admin_headers
+    ).json()["items"]
+    assert len(items) == 3
+    assert all(i["status"] == "pending" for i in items)
+    assert all(i["payload"]["source_video"] == "photos" for i in items)
+    assert sorted(i["payload"]["frame_index"] for i in items) == [1, 2, 3]
+
+    # frames are physically 640x640 on disk (always re-encoded to .jpg)
+    fdir = _frames_dir(_isolated_data_dir, pose_project["id"], "photos")
+    frames = sorted(fdir.glob("f_*.jpg"))
+    assert len(frames) == 3
+    for f in frames:
+        assert _probe_size(f) == (640, 640)
+
+
+def test_imported_items_carry_assignee(client, admin_headers, pose_project):
+    from app.schemas.user import UserRole
+    from app.services import user as user_service
+
+    user_service.ensure_seed_user("mate", "secret", UserRole.annotator)
+    uid = next(
+        u["id"] for u in client.get("/api/v1/users", headers=admin_headers).json()
+        if u["username"] == "mate"
+    )
+
+    z = _zip({"a.jpg": _img_bytes(320, 240), "b.jpg": _img_bytes(320, 240)})
+    r = _post_images(client, admin_headers, pose_project["id"], z, assignee_id=uid)
+    assert r.status_code == 201, r.text
+
+    items = client.get(
+        f"/api/v1/projects/{pose_project['id']}/items", headers=admin_headers
+    ).json()["items"]
+    assert len(items) == 2
+    assert all(i["assigned_to"] == uid for i in items)
+
+
+def test_rejects_non_pose_project(client, admin_headers):
+    seg = client.post(
+        "/api/v1/projects",
+        json={"name": "seg", "type": "image_segmentation"},
+        headers=admin_headers,
+    ).json()
+    z = _zip({"a.jpg": _img_bytes(320, 240)})
+    r = _post_images(client, admin_headers, seg["id"], z)
+    assert r.status_code == 400
+    assert "pose_detection" in r.json()["detail"]
+
+
+def test_rejects_non_admin(client, admin_headers, auth_headers, pose_project):
+    z = _zip({"a.jpg": _img_bytes(320, 240)})
+    r = _post_images(client, auth_headers, pose_project["id"], z)
+    assert r.status_code == 403
+
+
+def test_empty_file_rejected(client, admin_headers, pose_project):
+    r = _post_images(client, admin_headers, pose_project["id"], b"")
+    assert r.status_code == 400
+    assert "Empty" in r.json()["detail"]
+
+
+def test_corrupt_zip_rejected(client, admin_headers, pose_project):
+    r = _post_images(client, admin_headers, pose_project["id"], b"not a zip at all")
+    assert r.status_code == 400
+    assert "valid ZIP" in r.json()["detail"]
+
+
+def test_no_images_rejected(client, admin_headers, pose_project):
+    z = _zip({"notes.txt": b"hello", "data.csv": b"1,2,3"})
+    r = _post_images(client, admin_headers, pose_project["id"], z)
+    assert r.status_code == 400
+    assert "No images" in r.json()["detail"]
+
+
+def test_nested_folders_flatten_into_one_group(client, admin_headers, pose_project):
+    z = _zip({
+        "sub/dir/a.jpg": _img_bytes(320, 240),
+        "other/b.png": _img_bytes(320, 240, fmt="png"),
+        "c.jpg": _img_bytes(320, 240),
+    })
+    r = _post_images(client, admin_headers, pose_project["id"], z)
+    assert r.status_code == 201, r.text
+    assert r.json()["items_created"] == 3
+    items = client.get(
+        f"/api/v1/projects/{pose_project['id']}/items", headers=admin_headers
+    ).json()["items"]
+    assert {i["payload"]["source_video"] for i in items} == {"photos"}
+
+
+def test_non_image_files_skipped_and_counted(client, admin_headers, pose_project):
+    z = _zip({
+        "a.jpg": _img_bytes(320, 240),
+        "notes.txt": b"hello",
+        "readme.md": b"x",
+    })
+    r = _post_images(client, admin_headers, pose_project["id"], z)
+    assert r.status_code == 201, r.text
+    body = r.json()
+    assert body["items_created"] == 1
+    assert body["skipped_files"] == 2
+
+
+def test_stretch_mode_accepted_invalid_rejected(client, admin_headers, pose_project):
+    z = _zip({"a.jpg": _img_bytes(320, 240)})
+    ok = _post_images(client, admin_headers, pose_project["id"], z, resize_mode="stretch")
+    assert ok.status_code == 201, ok.text
+    assert ok.json()["resize_mode"] == "stretch"
+
+    z2 = _zip({"a.jpg": _img_bytes(320, 240)})
+    bad = _post_images(client, admin_headers, pose_project["id"], z2, resize_mode="weird")
+    assert bad.status_code == 400
+
+
+def test_reupload_continues_frame_index(client, admin_headers, pose_project):
+    first = _post_images(
+        client, admin_headers, pose_project["id"],
+        _zip({"a.jpg": _img_bytes(320, 240), "b.jpg": _img_bytes(320, 240)}),
+    )
+    assert first.status_code == 201, first.text
+    second = _post_images(
+        client, admin_headers, pose_project["id"],
+        _zip({"c.jpg": _img_bytes(320, 240), "d.jpg": _img_bytes(320, 240)}),
+    )
+    assert second.status_code == 201, second.text
+    assert second.json()["source_video"] == "photos"
+
+    items = client.get(
+        f"/api/v1/projects/{pose_project['id']}/items", headers=admin_headers
+    ).json()["items"]
+    assert sorted(i["payload"]["frame_index"] for i in items) == [1, 2, 3, 4]

--- a/docs/superpowers/specs/2026-06-15-image-zip-upload-design.md
+++ b/docs/superpowers/specs/2026-06-15-image-zip-upload-design.md
@@ -1,0 +1,236 @@
+# Image-ZIP upload — design
+
+**Date:** 2026-06-15
+**Status:** approved (design), pending implementation
+**Scope:** add the ability to ingest a ZIP of raw images into a pose
+project, alongside the existing video upload and COCO-keypoints import.
+
+## 1. Problem
+
+Today a `pose_detection` project gets frames in two ways:
+
+- **Upload video** (`POST /projects/{id}/videos`) — FFmpeg extracts frames
+  at a chosen FPS, resized to 640×640.
+- **Import COCO keypoints** (`POST /projects/{id}/import-coco`) — a ZIP
+  with `_annotations.coco.json` indexes; images are copied in at native
+  resolution and imported **already annotated**.
+
+There is no way to bring in a folder of **raw, unannotated images** to
+annotate from scratch. This spec adds that path: upload a `.zip` of
+images → one `pending` frame-item per image, ready for keypoint
+annotation.
+
+## 2. Decisions (settled during brainstorming)
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| **Resize** | Resize every image to **640×640** using the same `pad`/`stretch` filter as the video uploader (default `pad`). | Image frames become byte-consistent with video frames — same export geometry, one mental model. |
+| **Grouping** | **One group per ZIP**, named after the file (`photos.zip` → source `photos`). Subfolders are walked recursively but ignored for grouping. | Simplest; one row per upload in the Videos table. |
+| **Scope** | **`pose_detection` projects only.** | Mirrors `import-coco` gating; it's the only annotation workflow that consumes frames today. |
+| **Resize execution** | **One FFmpeg pass per image** (approach A). | Reuses the exact `scale/pad` + `-q:v 2` pipeline; no new dependency; ZIP images are heterogeneous so batch image2 demuxing is unreliable. |
+
+Rejected: Pillow in-process resize (new dep, JPEGs would differ subtly
+from the video path); per-subfolder grouping (more logic, not needed);
+optional/native-resolution mode (consistency with video frames was the
+explicit goal).
+
+## 3. Architecture
+
+Data flow, mirroring `import_coco.py`'s ZIP plumbing:
+
+```
+ZIP upload
+  → stream to temp file in 1 MiB chunks, cap 500 MiB   (ValueError on over/empty)
+  → _safe_extract into temp dir                         (path-traversal guard)
+  → rglob *.jpg/.jpeg/.png, sort by filename
+  → for each image:
+        ffmpeg -i <src> -vf <resize_filter(mode)> -q:v 2  frames/<zip>/f_NNNNNN.jpg
+        create item { payload{image_url, source_video=<zip>, frame_index, width:640, height:640},
+                      status: pending, assigned_to: assignee_id }
+  → return { items_created, skipped_files, source_video, resize_mode }
+```
+
+No schema change. Items are the **same shape** as video frames, so they
+flow through the Videos table, assignment, annotation, and export
+unchanged.
+
+### 3.1 Shared resize helper
+
+Extract the 640-resize constants and filter builder out of
+`services/video.py` so both the video uploader and the new image importer
+use one definition (keeps the two frame sources identical):
+
+- New module **`backend/app/services/frames.py`** exposing:
+  - `TARGET_SIZE = 640`, `RESIZE_MODES = ("stretch", "pad")`
+  - `resize_filter(mode: str) -> str` — the current `_resize_filter` body
+- `services/video.py` imports these and drops its private copies
+  (`_TARGET_SIZE`, `_PAD_COLOR`, `_RESIZE_MODES`, `_resize_filter`).
+  `_PAD_COLOR` moves to `frames.py` as a module constant used by
+  `resize_filter`.
+
+This is the only change to existing backend code; behavior of the video
+path is unchanged (same filter string emitted).
+
+### 3.2 New service — `services/image_import.py`
+
+Reuses `import_coco.py`'s helpers as a pattern (some can be lifted as-is):
+
+- `_SAFE` / `_safe_name(filename)` — group name from the ZIP filename.
+- `_safe_extract(zf, dest)` — identical path-traversal guard.
+- `_IMAGE_SUFFIXES = {".jpg", ".jpeg", ".png"}`.
+- `_MAX_ZIP_BYTES = 500 MiB`, `_CHUNK_BYTES = 1 MiB`.
+
+Main entry:
+
+```python
+def import_images(
+    project_id: int,
+    source: BinaryIO,
+    filename: str,
+    assignee_id: int | None = None,
+    resize_mode: str = "pad",
+) -> dict:
+```
+
+Behavior:
+
+1. Validate `resize_mode in frames.RESIZE_MODES` (else `ValueError`).
+2. Stream → cap → extract (as COCO import does).
+3. Walk `extract_dir.rglob("*")`, keep regular **files** whose suffix is
+   in `_IMAGE_SUFFIXES` (case-insensitive), sorted by path. Regular files
+   that are not images are counted as `skipped_files`; directories are
+   ignored (not counted).
+4. `source_name = _safe_name(filename)`. **frame_index continues
+   contiguously** from any existing frames in
+   `frames/<source_name>/` (same counter logic as COCO import), so
+   re-uploading extends the group rather than colliding.
+5. For each image: run FFmpeg resize into
+   `frames/<source_name>/f_{idx:06d}.jpg` (always `.jpg`, since we
+   re-encode — matches video frames). On non-zero ffmpeg exit, raise
+   `RuntimeError` (→ 500), consistent with the video path.
+6. Create one `pending` item per successfully written frame with
+   `payload = {image_url, source_video, frame_index, width: 640,
+   height: 640}` and `assigned_to = assignee_id`.
+7. If `items_created == 0` (no images in archive) → `ValueError`
+   ("No images found in archive").
+8. Return `{items_created, skipped_files, source_video, resize_mode}`.
+
+Unlike COCO import, this creates **no annotations** — items are blank/
+pending. `uploader_id` is therefore not needed.
+
+### 3.3 New endpoint — `api/v1/videos.py`
+
+```python
+@router.post("/projects/{project_id}/import-images", status_code=201, tags=["videos"])
+async def import_images(
+    project_id: int,
+    current_user: AdminUser,
+    file: UploadFile = File(...),
+    assignee_id: int | None = Form(None),
+    resize_mode: str = Form("pad"),
+) -> dict:
+```
+
+- `_require_project(project_id)`; gate `project.type.value == "pose_detection"`
+  else `400` (same message style as `import-coco`).
+- `_require_user(assignee_id)` when provided.
+- Call `image_import_service.import_images(...)`.
+- `ValueError → 413` if `"larger than"` in message else `400`;
+  `RuntimeError → 500` — same mapping the other two endpoints use.
+
+### 3.4 Frontend
+
+**`api/videos.ts`**
+
+```ts
+export interface ImageImportResult {
+  items_created: number;
+  skipped_files: number;
+  source_video: string;
+  resize_mode: ResizeMode;
+}
+
+export async function importImages(
+  projectId: number,
+  file: File,
+  assigneeId: number | null,
+  resizeMode: ResizeMode = 'pad',
+): Promise<ImageImportResult>
+```
+
+(FormData with `file`, optional `assignee_id`, `resize_mode`;
+`multipart/form-data`.)
+
+**`pages/ProjectDetailPage.tsx`** — new `<details>` card **"Upload images
+(ZIP)"**, gated `isPose && isAdmin`, placed **immediately after "Upload
+video"**. Structure mirrors the COCO card:
+
+- Dropzone accepting `.zip` (copy: "Click to choose an images ZIP — JPG/PNG").
+- **Resize radio** reusing the video card's Keep-aspect-ratio / Stretch
+  markup (default `pad`).
+- Assignee `<select>` (same options as the other cards).
+- Submit button "Upload & extract" (disabled until a file is chosen).
+- Result summary after success: "Created N items · skipped M files".
+
+New local state (`imagesFile`, `imagesAssignee`, `imagesResizeMode`,
+`imagesResult`) and a `imagesImport` `useMutation` cloned from
+`cocoImport`, invalidating `['items', projectId]` and
+`['videos', projectId]` on success so the new group appears in the
+Videos table immediately.
+
+## 4. Errors & edge cases
+
+| Case | Result |
+|---|---|
+| Non-pose project | `400` (endpoint gate) |
+| Empty upload | `400` "Empty file" |
+| Not a ZIP / corrupt | `400` "Not a valid ZIP: …" |
+| ZIP with no images | `400` "No images found in archive" |
+| Over 500 MiB | `413` |
+| Path traversal in archive | `400` "Unsafe path in archive: …" |
+| Non-image files mixed in | Skipped, counted in `skipped_files` |
+| Nested subfolders | Walked recursively, all flattened into one group |
+| FFmpeg failure on an image | `500` (whole upload fails; partial frames may remain — acceptable, admin retries) |
+| Re-upload same ZIP name | Extends the existing group; `frame_index` continues contiguously |
+
+## 5. Testing — `tests/test_image_import.py`
+
+Build small in-memory ZIPs with `zipfile` + tiny generated JPEG/PNG
+bytes (or Pillow if already available in test env; otherwise minimal
+valid image bytes). Cases:
+
+1. **Happy path** — 2–3 images → `items_created` matches; each frame on
+   disk is 640×640; items are `pending`; `source_video` == zip stem;
+   `frame_index` is 1..N.
+2. **Assignee wiring** — `assigned_to` set on every created item.
+3. **Gating** — non-pose project → `400`.
+4. **Empty file** → `400`; **corrupt ZIP** → `400`.
+5. **No images** (ZIP of only `.txt`) → `400` "No images found in
+   archive" (raised before any dict is returned).
+6. **Nested folders** flatten into one group.
+7. **Mixed non-image files** skipped and counted.
+8. **resize_mode** — `stretch` accepted; invalid mode → `400`.
+9. **Contiguous re-upload** — second upload of same name continues
+   `frame_index` past the first.
+
+Backend tests run in-container via `pytest`; use existing fixtures
+(`client`, `admin_headers`, isolated `DATA_DIR`).
+
+## 6. Docs to update (before/with code)
+
+- **SPEC.md** — ingest section: document `import-images` alongside the
+  video and COCO paths; note Phase 3 gains raw-image ingest.
+- **README.md** — "What you can do" step 1: mention "or upload a ZIP of
+  images".
+- **CLAUDE.md** — `videos.py` pointer: note it also hosts the
+  image-ZIP importer (`POST /projects/{id}/import-images`).
+
+## 7. Out of scope (YAGNI)
+
+- Per-subfolder grouping.
+- Native-resolution / optional-resize mode.
+- Non-pose project types (Phase 6 image classification/bbox — no UI yet).
+- Importing images with sidecar annotations (that's what COCO import is
+  for).
+- Per-image rotation on import (the Videos table already has per-group
+  rotate post-upload).

--- a/frontend/src/api/videos.ts
+++ b/frontend/src/api/videos.ts
@@ -78,6 +78,31 @@ export async function importCocoPose(
   return data;
 }
 
+export interface ImageImportResult {
+  items_created: number;
+  skipped_files: number;
+  source_video: string;
+  resize_mode: ResizeMode;
+}
+
+export async function importImages(
+  projectId: number,
+  file: File,
+  assigneeId: number | null,
+  resizeMode: ResizeMode = 'pad',
+): Promise<ImageImportResult> {
+  const form = new FormData();
+  form.append('file', file);
+  if (assigneeId !== null) form.append('assignee_id', String(assigneeId));
+  form.append('resize_mode', resizeMode);
+  const { data } = await api.post<ImageImportResult>(
+    `/projects/${projectId}/import-images`,
+    form,
+    { headers: { 'Content-Type': 'multipart/form-data' } },
+  );
+  return data;
+}
+
 export async function deleteVideo(projectId: number, sourceVideo: string) {
   const { data } = await api.delete<{ deleted: number }>(
     `/projects/${projectId}/videos/${encodeURIComponent(sourceVideo)}`,

--- a/frontend/src/pages/ProjectDetailPage.tsx
+++ b/frontend/src/pages/ProjectDetailPage.tsx
@@ -22,9 +22,9 @@ import {
   type OutlierItem,
 } from '@/api/items';
 import { listUsers } from '@/api/users';
-import { deleteVideo, importCocoPose, listVideos, reassignVideo, rotateVideo, uploadVideo } from '@/api/videos';
+import { deleteVideo, importCocoPose, importImages, listVideos, reassignVideo, rotateVideo, uploadVideo } from '@/api/videos';
 import { VideoRotateButtons } from '@/features/projects/VideoRotateButtons';
-import type { CocoImportResult, ResizeMode } from '@/api/videos';
+import type { CocoImportResult, ImageImportResult, ResizeMode } from '@/api/videos';
 import { downloadExport, type ExportFormat } from '@/lib/download';
 import { frameUrl } from '@/lib/frameUrl';
 import { useConfirm } from '@/components/ui/ConfirmDialog';
@@ -87,6 +87,10 @@ export default function ProjectDetailPage() {
   const [importFile, setImportFile] = useState<File | null>(null);
   const [importAssignee, setImportAssignee] = useState<number | ''>('');
   const [importResult, setImportResult] = useState<CocoImportResult | null>(null);
+  const [imagesFile, setImagesFile] = useState<File | null>(null);
+  const [imagesAssignee, setImagesAssignee] = useState<number | ''>('');
+  const [imagesResizeMode, setImagesResizeMode] = useState<ResizeMode>('pad');
+  const [imagesResult, setImagesResult] = useState<ImageImportResult | null>(null);
   const videoPreviewUrl = useMemo(
     () => (videoFile ? URL.createObjectURL(videoFile) : null),
     [videoFile],
@@ -226,6 +230,22 @@ export default function ProjectDetailPage() {
     onSuccess: (data) => {
       setImportResult(data);
       setImportFile(null);
+      qc.invalidateQueries({ queryKey: ['items', projectId] });
+      qc.invalidateQueries({ queryKey: ['videos', projectId] });
+    },
+  });
+
+  const imagesImport = useMutation({
+    mutationFn: () =>
+      importImages(
+        projectId,
+        imagesFile!,
+        imagesAssignee === '' ? null : imagesAssignee,
+        imagesResizeMode,
+      ),
+    onSuccess: (data) => {
+      setImagesResult(data);
+      setImagesFile(null);
       qc.invalidateQueries({ queryKey: ['items', projectId] });
       qc.invalidateQueries({ queryKey: ['videos', projectId] });
     },
@@ -1166,6 +1186,201 @@ export default function ProjectDetailPage() {
         </section>
         ) : null
       ) : null}
+
+      {/* Upload images ZIP (admin, pose projects) */}
+      {isPose && isAdmin && (
+        <section className="bg-white rounded-lg shadow">
+          <details className="group">
+            <summary className="flex items-center justify-between gap-3 cursor-pointer px-4 py-3 select-none hover:bg-slate-50 rounded-lg">
+              <div className="min-w-0">
+                <h2 className="font-semibold">Upload images (ZIP)</h2>
+                <p className="text-xs text-slate-500">
+                  Drop a ZIP of images (JPG/PNG). Each image becomes one pending
+                  frame resized to 640 × 640; all images are grouped under a
+                  single source named after the ZIP file.
+                </p>
+              </div>
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="18"
+                height="18"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                className="shrink-0 text-slate-400 transition-transform group-open:rotate-180"
+              >
+                <polyline points="6 9 12 15 18 9" />
+              </svg>
+            </summary>
+            <div className="px-4 pb-4 pt-3 border-t space-y-4">
+
+          {!imagesFile ? (
+            <label
+              className="flex flex-col items-center justify-center gap-2 px-6 py-8 border-2 border-dashed border-slate-200 bg-slate-50 rounded-lg cursor-pointer hover:bg-slate-100 hover:border-slate-300 transition-colors"
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="28"
+                height="28"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.6"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                className="text-slate-400"
+              >
+                <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+                <polyline points="17 8 12 3 7 8" />
+                <line x1="12" y1="3" x2="12" y2="15" />
+              </svg>
+              <span className="text-sm font-medium text-slate-700">
+                Click to choose an images ZIP
+              </span>
+              <span className="text-xs text-slate-500">
+                JPG / PNG files inside a .zip
+              </span>
+              <input
+                type="file"
+                accept=".zip,application/zip"
+                onChange={(e) => {
+                  setImagesFile(e.target.files?.[0] ?? null);
+                  setImagesResult(null);
+                }}
+                className="hidden"
+              />
+            </label>
+          ) : (
+            <div className="flex items-center gap-3 p-3 border rounded-lg bg-slate-50">
+              <div className="flex-1 min-w-0">
+                <div className="font-medium truncate" title={imagesFile.name}>
+                  {imagesFile.name}
+                </div>
+                <div className="text-xs text-slate-500">
+                  {formatBytes(imagesFile.size)}
+                </div>
+              </div>
+              <button
+                onClick={() => setImagesFile(null)}
+                className="text-xs border rounded px-2 py-1 text-red-600 hover:bg-red-50"
+              >
+                Remove
+              </button>
+            </div>
+          )}
+
+          <div className="space-y-1">
+            <label className="text-xs font-medium text-slate-600 uppercase tracking-wide">
+              Resize to 640 × 640
+            </label>
+            <div className="grid sm:grid-cols-2 gap-2">
+              <label
+                className={`flex items-start gap-2 border rounded px-3 py-2 cursor-pointer text-sm ${
+                  imagesResizeMode === 'pad'
+                    ? 'border-blue-500 bg-blue-50'
+                    : 'border-slate-200 hover:bg-slate-50'
+                }`}
+              >
+                <input
+                  type="radio"
+                  name="img-resize-mode"
+                  value="pad"
+                  checked={imagesResizeMode === 'pad'}
+                  onChange={() => setImagesResizeMode('pad')}
+                  className="mt-0.5"
+                />
+                <span>
+                  <span className="font-medium">Keep aspect ratio</span>{' '}
+                  <span className="text-xs text-emerald-700">(recommended)</span>
+                  <span className="block text-xs text-slate-500">
+                    Letterbox with black bars — no distortion.
+                  </span>
+                </span>
+              </label>
+              <label
+                className={`flex items-start gap-2 border rounded px-3 py-2 cursor-pointer text-sm ${
+                  imagesResizeMode === 'stretch'
+                    ? 'border-blue-500 bg-blue-50'
+                    : 'border-slate-200 hover:bg-slate-50'
+                }`}
+              >
+                <input
+                  type="radio"
+                  name="img-resize-mode"
+                  value="stretch"
+                  checked={imagesResizeMode === 'stretch'}
+                  onChange={() => setImagesResizeMode('stretch')}
+                  className="mt-0.5"
+                />
+                <span>
+                  <span className="font-medium">Stretch</span>
+                  <span className="block text-xs text-slate-500">
+                    Fill the frame — distorts non-square sources.
+                  </span>
+                </span>
+              </label>
+            </div>
+          </div>
+
+          <div className="space-y-1">
+            <label className="text-xs font-medium text-slate-600 uppercase tracking-wide">
+              Assign to
+            </label>
+            <select
+              value={imagesAssignee}
+              onChange={(e) =>
+                setImagesAssignee(e.target.value ? Number(e.target.value) : '')
+              }
+              className="border rounded px-2 py-1.5 text-sm w-full sm:w-64"
+            >
+              <option value="">— leave unassigned —</option>
+              {(usersQ.data ?? []).map((u) => (
+                <option key={u.id} value={u.id}>
+                  {u.username} ({u.role})
+                </option>
+              ))}
+            </select>
+            <div className="text-xs text-slate-500">
+              Optional — assign later from the videos table if you prefer.
+            </div>
+          </div>
+
+          <div className="flex items-center justify-end pt-2 border-t">
+            <button
+              onClick={() => imagesImport.mutate()}
+              disabled={!imagesFile || imagesImport.isPending}
+              className="inline-flex items-center gap-2 bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700 disabled:opacity-50 text-sm font-medium"
+            >
+              {imagesImport.isPending ? 'Uploading…' : 'Upload images'}
+            </button>
+          </div>
+
+          {imagesImport.isError && (
+            <p className="text-sm text-red-600">
+              {(imagesImport.error as { response?: { data?: { detail?: string } } })
+                ?.response?.data?.detail ?? 'Upload failed'}
+            </p>
+          )}
+          {imagesResult && (
+            <div className="text-sm text-emerald-700 space-y-0.5">
+              <p>
+                Created <b>{imagesResult.items_created}</b> frames
+                {imagesResult.skipped_files > 0 && (
+                  <>{' · '}<b>{imagesResult.skipped_files}</b> non-image files skipped</>
+                )}
+              </p>
+              <p className="text-xs text-slate-500">
+                Grouped under: {imagesResult.source_video}
+              </p>
+            </div>
+          )}
+            </div>
+          </details>
+        </section>
+      )}
 
       {/* Import COCO-pose (admin, pose projects) */}
       {isPose && isAdmin && (


### PR DESCRIPTION
## Summary

Adds a third ingest path for pose projects: upload a ZIP of raw images and get
one **pending** frame per image, ready for keypoint annotation — alongside the
existing video upload and COCO-keypoints import.

`POST /projects/{id}/import-images` (admin-only, pose projects only):
- Streams the ZIP to disk (500 MiB cap → 413), path-safe-extracts.
- Recursively finds `.jpg/.jpeg/.png`, re-encodes each to **640×640** using the
  same FFmpeg resize as video upload, so image frames and video frames are
  interchangeable downstream.
- Creates one `pending` item per image, grouped under a single source named
  after the ZIP. `frame_index` continues contiguously on re-upload.
- Returns `{items_created, skipped_files, source_video, resize_mode}`.

## Changes

**Backend**
- `services/frames.py` — extracted the shared 640 resize filter (video + image
  import now share one definition).
- `services/image_import.py` — the new importer (mirrors `import_coco.py`'s ZIP
  plumbing: stream/cap → safe-extract → per-image ffmpeg resize → pending item).
- `api/v1/videos.py` — new endpoint, admin + pose-gated.
- Refactor note: `video.py` uses a local `frames` variable, so the shared
  helpers are imported by name to avoid an `UnboundLocalError` shadow.

**Frontend**
- `api/videos.ts` — `importImages()` + `ImageImportResult`.
- `ProjectDetailPage.tsx` — new "Upload images (ZIP)" card after "Upload video",
  with the Keep-aspect/Stretch radio and a result summary.

**Docs** — SPEC (new endpoint + Phase 3 note) and README updated. Design spec at
`docs/superpowers/specs/2026-06-15-image-zip-upload-design.md`.

## Tests

`tests/test_image_import.py` (11 cases, real ffmpeg): happy path (frames
verified 640×640 via ffprobe), assignee wiring, non-pose 400, non-admin 403,
empty/corrupt/no-image ZIPs, nested-folder flatten, non-image skip-count,
stretch/invalid resize mode, contiguous re-upload. Backend suite green (the one
pre-existing `pycocotools` failure is env-only, passes in Docker). Frontend
typecheck passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
